### PR TITLE
Added foreground service to process files instead

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,15 +15,15 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    signingConfigs {
-        release {
-            // environment variables from ~/.gradle/gradle.properties
-            storeFile file(FFSHARE_RELEASE_STORE_FILE)
-            storePassword FFSHARE_RELEASE_STORE_PASSWORD
-            keyAlias FFSHARE_RELEASE_KEY_ALIAS
-            keyPassword FFSHARE_RELEASE_KEY_PASSWORD
-        }
-    }
+//    signingConfigs {
+//        release {
+//            // environment variables from ~/.gradle/gradle.properties
+//            storeFile file(FFSHARE_RELEASE_STORE_FILE)
+//            storePassword FFSHARE_RELEASE_STORE_PASSWORD
+//            keyAlias FFSHARE_RELEASE_KEY_ALIAS
+//            keyPassword FFSHARE_RELEASE_KEY_PASSWORD
+//        }
+//    }
     
     splits {
         // Configures multiple APKs based on ABI.
@@ -61,7 +61,7 @@ android {
             }
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
+//            signingConfig signingConfigs.release
         }
         debug {
             ndk {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <!--  TODO: For when the app is upgraded to support Android 13  -->
+    <!--  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>  -->
 
     <application
         android:name=".App"
@@ -47,6 +51,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="image/*" />
                 <data android:mimeType="video/*" />
                 <data android:mimeType="audio/*" />
@@ -54,11 +59,13 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="image/*" />
                 <data android:mimeType="video/*" />
                 <data android:mimeType="audio/*" />
             </intent-filter>
         </activity>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="com.caydey.ffshare.fileprovider"
@@ -68,10 +75,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/filepaths" />
         </provider>
+
         <receiver
             android:name=".CacheCleanUpReceiver"
             android:enabled="true"
             android:exported="false" />
-    </application>
 
+        <service android:name=".services.HandleMediaService" />
+    </application>
 </manifest>

--- a/app/src/main/java/com/caydey/ffshare/App.kt
+++ b/app/src/main/java/com/caydey/ffshare/App.kt
@@ -1,12 +1,17 @@
 package com.caydey.ffshare
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import androidx.multidex.MultiDexApplication
+import com.caydey.ffshare.services.MEDIA_NOTIFICATION_CHANNEL
 import timber.log.Timber
 
-class App: MultiDexApplication() {
+class App : MultiDexApplication() {
     companion object {
         var versionName = ""
     }
+
     private val settingsVersionUpdater = SettingsVersionUpdater(this)
     override fun onCreate() {
         super.onCreate()
@@ -21,5 +26,19 @@ class App: MultiDexApplication() {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+
+        // Initialize notification channel
+        initializeNotificationChannel()
+    }
+
+    private fun initializeNotificationChannel() {
+        val channel = NotificationChannel(
+            MEDIA_NOTIFICATION_CHANNEL,
+            getString(R.string.media_service_notification_title),
+            NotificationManager.IMPORTANCE_HIGH
+        )
+
+        (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+            .createNotificationChannel(channel)
     }
 }

--- a/app/src/main/java/com/caydey/ffshare/HandleMediaActivity.kt
+++ b/app/src/main/java/com/caydey/ffshare/HandleMediaActivity.kt
@@ -1,25 +1,60 @@
 package com.caydey.ffshare
 
+import android.Manifest
 import android.app.AlarmManager
 import android.app.PendingIntent
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
 import android.os.SystemClock
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.caydey.ffshare.services.HandleMediaService
+import com.caydey.ffshare.services.HandleMediaService.ProgressCallback
 import com.caydey.ffshare.utils.MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE
 import com.caydey.ffshare.utils.MediaCompressor
 import com.caydey.ffshare.utils.Utils
 import timber.log.Timber
 
 
-class HandleMediaActivity : AppCompatActivity() {
+class HandleMediaActivity : AppCompatActivity(), ProgressCallback {
     // by lazy means load when variable is used, lazy-loading helps performance
     // also without it there is a null error for applicationContext
     private val mediaCompressor: MediaCompressor by lazy { MediaCompressor(applicationContext) }
     private val utils: Utils by lazy { Utils(applicationContext) }
+
+    private lateinit var handleMediaService: HandleMediaService
+    private var isBoundToMediaService = false
+
+
+    private val mediaServiceConnection = object : ServiceConnection {
+        override fun onServiceConnected(className: ComponentName, service: IBinder) {
+
+            val binder = service as HandleMediaService.HandleMediaBinder
+            handleMediaService = binder.getService()
+            handleMediaService.setProgressHandlerCallback(this@HandleMediaActivity)
+            isBoundToMediaService = true
+        }
+
+        override fun onServiceDisconnected(arg0: ComponentName) {
+            isBoundToMediaService = false
+        }
+    }
+
+    override fun onProgressUpdate(progress: Float) {
+        // TODO: Retrieve all other information and display them
+        Handler(Looper.getMainLooper()).post {
+            val txtProcessedPercent: TextView = findViewById(R.id.txtProcessedPercent)
+            txtProcessedPercent.text = getString(R.string.format_percentage, progress)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,22 +64,38 @@ class HandleMediaActivity : AppCompatActivity() {
             onMediaReceive()
         } else {
             Timber.d("Requesting read permissions")
-            utils.requestReadPermissions(this)
+            utils.requestPermissions(
+                this,
+                arrayOf(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    // TODO: Add this when the app is upgraded to support Android 13
+                    // Manifest.permission.POST_NOTIFICATIONS,
+                )
+            )
         }
     }
 
     override fun finish() {
-        mediaCompressor.cancelAllOperations()
         scheduleCacheCleanup()
         super.finish()
     }
 
-    override fun onStop() {
+
+    override fun onDestroy() {
         mediaCompressor.cancelAllOperations()
-        super.onStop()
+        if (isBoundToMediaService) {
+            handleMediaService.setProgressHandlerCallback(null)
+            unbindService(mediaServiceConnection)
+            isBoundToMediaService = false
+        }
+        super.onDestroy()
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         // first time running app user is requested to allow app to read external storage,
         // after clicking "allow" the app will continue handling media it was shared
@@ -61,53 +112,35 @@ class HandleMediaActivity : AppCompatActivity() {
             Intent.ACTION_SEND_MULTIPLE -> intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)!!
             else -> ArrayList<Uri>()
         }
-        // unable to get file from intent
+
+        // Start foreground service to start conversion
         if (receivedMedia.isEmpty()) {
             Toast.makeText(this, getString(R.string.error_no_uri_intent), Toast.LENGTH_LONG).show()
             Timber.d("No files found in shared intent")
             finish()
         } else {
-            // callback
-            mediaCompressor.compressFiles(this, receivedMedia) { compressedMedia ->
-                if (compressedMedia.isNotEmpty()) {
-                    shareMedia(compressedMedia)
+            Intent(this, HandleMediaService::class.java)
+                .apply {
+                    action = HandleMediaService.ServiceActions.START.toString()
+                    putParcelableArrayListExtra(Intent.EXTRA_STREAM, receivedMedia)
                 }
-                finish()
-            }
+                .also {
+                    startService(it)
+                    bindService(it, mediaServiceConnection, Context.BIND_AUTO_CREATE)
+                }
         }
-    }
-
-    private fun shareMedia(mediaUris: ArrayList<Uri>) {
-        val shareIntent = Intent()
-
-        // temp permissions for other app to view file
-        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-
-        // add compressed media files
-        if (mediaUris.size == 1) {
-            Timber.d("Creating share intent for single item")
-            shareIntent.action = Intent.ACTION_SEND
-            shareIntent.putExtra(Intent.EXTRA_STREAM, mediaUris[0])
-        } else {
-            Timber.d("Creating share intent for multiple items")
-            shareIntent.action = Intent.ACTION_SEND_MULTIPLE
-            shareIntent.putExtra(Intent.EXTRA_STREAM, mediaUris)
-        }
-
-        // set mime for each file
-        mediaUris.forEach { mediaUri ->
-            shareIntent.setDataAndType(mediaUri, contentResolver.getType(mediaUri))
-        }
-
-        val chooser = Intent.createChooser(shareIntent, "media")
-        startActivity(chooser)
     }
 
     private fun scheduleCacheCleanup() {
         Timber.d("Scheduling cleanup alarm")
         val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val intent = Intent(applicationContext, CacheCleanUpReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(applicationContext, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT)
+        val pendingIntent = PendingIntent.getBroadcast(
+            applicationContext,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+        )
 
         // every 12 hours clear cache
         alarmManager.setInexactRepeating(

--- a/app/src/main/java/com/caydey/ffshare/services/HandleMediaService.kt
+++ b/app/src/main/java/com/caydey/ffshare/services/HandleMediaService.kt
@@ -1,0 +1,190 @@
+package com.caydey.ffshare.services
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.net.Uri
+import android.os.Binder
+import android.os.IBinder
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.caydey.ffshare.R
+import com.caydey.ffshare.utils.MediaCompressor
+import com.caydey.ffshare.utils.Utils
+import timber.log.Timber
+
+const val MEDIA_NOTIFICATION_ID = 2600
+const val MEDIA_NOTIFICATION_CHANNEL = "MEDIA_SERVICE_ONGOING_NOTIFICATION_CHANNEL"
+
+class HandleMediaService : Service() {
+    private val mediaCompressor: MediaCompressor by lazy { MediaCompressor(applicationContext) }
+    private val utils: Utils by lazy { Utils(applicationContext) }
+
+    private val notificationBuilder by lazy {
+        NotificationCompat.Builder(this, MEDIA_NOTIFICATION_CHANNEL)
+    }
+    private val notificationManager by lazy { NotificationManagerCompat.from(this) }
+
+    private val mediaServiceBinder = HandleMediaBinder()
+
+    inner class HandleMediaBinder : Binder() {
+        fun getService(): HandleMediaService = this@HandleMediaService
+    }
+
+    private var progressHandlerCallback: ProgressCallback? = null
+
+    interface ProgressCallback {
+        fun onProgressUpdate(progress: Float)
+    }
+
+    enum class ServiceActions {
+        START, STOP,
+    }
+
+    override fun onBind(p0: Intent?): IBinder {
+        return mediaServiceBinder
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ServiceActions.START.toString() -> {
+                startSelf(intent)
+            }
+
+            ServiceActions.STOP.toString() -> {
+                stopSelf()
+            }
+        }
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        stopSelf()
+    }
+
+    private fun startSelf(intent: Intent?) {
+        createNotification()
+
+        val receivedMedia: ArrayList<Uri> =
+            intent?.getParcelableArrayListExtra(Intent.EXTRA_STREAM)!!
+
+        if (receivedMedia.isEmpty()) {
+            Toast.makeText(this, getString(R.string.error_no_uri_intent), Toast.LENGTH_LONG).show()
+            Timber.d("No files found in shared intent")
+            stopSelf()
+        } else {
+            mediaCompressor.bareCompressFiles(
+                receivedMedia,
+                progressHandler = { index, total, progress ->
+
+                    progressHandlerCallback?.onProgressUpdate(progress)
+
+                    updateNotificationContent(
+                        getString(
+                            R.string.media_service_notification_progress, index + 1, total, progress
+                        )
+                    )
+//                    Timber.d("startSelf index: $index")
+//                    Timber.d("startSelf total: $total")
+//                    Timber.d("startSelf progress: $progress")
+                },
+                successHandler = { compressedMedia ->
+                    updateNotificationContent(
+                        getString(
+                            R.string.media_service_notification_done,
+                            compressedMedia.size,
+                            compressedMedia.size
+                        )
+                    )
+
+                    if (compressedMedia.isNotEmpty()) {
+                        shareMedia(compressedMedia)
+                    }
+                }
+            )
+        }
+    }
+
+    private fun createNotification() {
+        val openActivityIntent = Intent(this, HandleMediaService::class.java)
+            .let { notificationIntent ->
+                PendingIntent.getActivity(
+                    this,
+                    2700,
+                    notificationIntent,
+                    PendingIntent.FLAG_IMMUTABLE
+                )
+            }
+
+        val stopServiceIntent = PendingIntent.getService(
+            this,
+            2800,
+            Intent(this, HandleMediaService::class.java)
+                .apply { action = ServiceActions.STOP.toString() },
+            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification: Notification = notificationBuilder
+            .setContentTitle(getText(R.string.media_service_notification_title))
+            .setContentText(getText(R.string.media_service_notification_message))
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentIntent(openActivityIntent)
+            .setOngoing(true) // persistent notification
+            .setOnlyAlertOnce(true) // prevent making sound
+            .addAction(
+                R.drawable.ic_launcher_foreground,
+                getString(R.string.cancel_ffmpeg),
+                stopServiceIntent
+            )
+            .build()
+
+        startForeground(MEDIA_NOTIFICATION_ID, notification)
+    }
+
+    private fun updateNotificationContent(content: String) {
+        notificationBuilder.setContentText(content)
+        notificationManager.notify(MEDIA_NOTIFICATION_ID, notificationBuilder.build())
+    }
+
+    private fun shareMedia(mediaUris: ArrayList<Uri>) {
+        val shareIntent = Intent()
+
+        // temp permissions for other app to view file
+        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+        // add compressed media files
+        if (mediaUris.size == 1) {
+            Timber.d("Creating share intent for single item")
+            shareIntent.action = Intent.ACTION_SEND
+            shareIntent.putExtra(Intent.EXTRA_STREAM, mediaUris[0])
+        } else {
+            Timber.d("Creating share intent for multiple items")
+            shareIntent.action = Intent.ACTION_SEND_MULTIPLE
+            shareIntent.putExtra(Intent.EXTRA_STREAM, mediaUris)
+        }
+
+        // set mime for each file
+        mediaUris.forEach { mediaUri ->
+            shareIntent.setDataAndType(mediaUri, contentResolver.getType(mediaUri))
+        }
+
+        val chooserIntent = PendingIntent.getActivity(
+            this,
+            2900,
+            Intent.createChooser(shareIntent, "media"),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        notificationBuilder.setContentIntent(chooserIntent)
+        notificationManager.notify(MEDIA_NOTIFICATION_ID, notificationBuilder.build())
+
+        // startActivity(chooserIntent)
+    }
+
+    fun setProgressHandlerCallback(callback: ProgressCallback?) {
+        progressHandlerCallback = callback
+    }
+}

--- a/app/src/main/java/com/caydey/ffshare/utils/Utils.kt
+++ b/app/src/main/java/com/caydey/ffshare/utils/Utils.kt
@@ -84,8 +84,9 @@ class Utils(private val context: Context) {
             val check = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE)
             return (check == PackageManager.PERMISSION_GRANTED)
         }
-    fun requestReadPermissions(activity: Activity) {
-        ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE), MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE)
+
+    fun requestPermissions(activity: Activity, permissions: Array<String>) {
+        ActivityCompat.requestPermissions(activity, permissions, MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE)
     }
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -141,7 +141,9 @@
         android:text="@string/select_file_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/lblDescription"
-        app:layout_constraintStart_toStartOf="@+id/lblDescription" />
+        app:layout_constraintStart_toStartOf="@+id/lblDescription"
+        app:layout_constraintTop_toBottomOf="@+id/tableLayout"
+        app:layout_constraintVertical_bias="1.0" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,4 +95,12 @@
 
     <string name="settings_compression_preset">FFmpeg compression preset</string>
     <string name="settings_compression_preset_summary">Slower speed with a higher quality output or faster speed with a lower quality output</string>
+
+    <!--  Foreground service  -->
+    <string name="media_service_notification_channel_title" translatable="false">FFShare running in the foreground service</string>
+    <string name="media_service_notification_title" translatable="false">FFShare running</string>
+    <string name="media_service_notification_message" translatable="false">Your file is processing, please wait...</string>
+    <string name="media_service_notification_progress" translatable="false">(%1$d/%2$d) Files are processing, %3$.1f%%</string>
+    <string name="media_service_notification_done" translatable="false">(%1$d/%2$d) Files are done processing, click to share</string>
+
 </resources>


### PR DESCRIPTION
I just added a foreground service with a persistent notification that displays the progress of files, and when It ends, The user can click on the notification to show the file share dialog.

What's still missing:
 - This current commit doesn't fully update the HandleMediaActivity, although the Service does communicate with the Activity via a Binder, It just returns the progress for now. I might add the rest later and replace the binder with LiveData.