### PR TITLE
Fixes #54 also added `libx265` video codec

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.caydey.ffshare"
         minSdk 26
         targetSdk 32
-        versionCode 16
-        versionName "1.2.8"
+        versionCode 17
+        versionName "1.2.8a"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -107,8 +107,8 @@ dependencies {
 
     // import ffmpeg-kit-full if building with audioSupport
     // else import ffmpeg-kit-min
-    fullImplementation 'com.arthenica:ffmpeg-kit-full-gpl:6.0'
-    videoImplementation 'com.arthenica:ffmpeg-kit-min-gpl:6.0'
+    fullImplementation 'com.arthenica:ffmpeg-kit-full-gpl:5.1'
+    videoImplementation 'com.arthenica:ffmpeg-kit-min-gpl:5.1'
 
     implementation 'com.jakewharton.timber:timber:5.0.1'
 

--- a/app/src/main/java/com/caydey/ffshare/utils/MediaCompressor.kt
+++ b/app/src/main/java/com/caydey/ffshare/utils/MediaCompressor.kt
@@ -254,7 +254,7 @@ class MediaCompressor(private val context: Context) {
 
             // h264 codec for mp4
             if (outputMediaType == Utils.MediaType.MP4) {
-                params.add("-c:v h264")
+                params.add("-c:v ${settings.videoCodec}")
             }
 
             //  max file size (limit the bitrate to achieve this)
@@ -297,10 +297,14 @@ class MediaCompressor(private val context: Context) {
             if (resolution > maxResolution && maxResolution != 0) {
                 if (isPortrait) {
                     // rescale width
-                    params.add("-vf scale=$maxResolution:-1,setsar=1")
+                    val height_f = resolutionWidth/(resolutionHeight.toFloat()/maxResolution)
+                    val height = if (height_f.toInt()%2==0) height_f.toInt() else (height_f.toInt() + 1)
+                    params.add("-vf scale=$maxResolution:$height,setsar=1")
                 } else {
                     // rescale height
-                    params.add("-vf scale=-1:$maxResolution,setsar=1")
+                    val width_f = resolutionHeight/(resolutionWidth.toFloat()/maxResolution)
+                    val width = if (width_f.toInt()%2==0) width_f.toInt() else (width_f.toInt() + 1)
+                    params.add("-vf scale=$width:$maxResolution,setsar=1")
                 }
             }
         }

--- a/app/src/main/java/com/caydey/ffshare/utils/Settings.kt
+++ b/app/src/main/java/com/caydey/ffshare/utils/Settings.kt
@@ -79,6 +79,9 @@ class Settings(private val context: Context) {
         get() = preferences.getString(COMPRESSION_PRESET, "medium")!!
         set(value) = setPreference(COMPRESSION_PRESET, value)
 
+    var videoCodec: String
+        get() = preferences.getString(VIDEO_CODEC, "libx265")!!
+        set(value) = setPreference(VIDEO_CODEC, value)
     private fun setPreference(key: String, value: String) {
         preferences.edit().putString(key, value).apply()
     }
@@ -106,5 +109,6 @@ class Settings(private val context: Context) {
         const val LAST_VERSION = "pref_last_version"
         const val SAVE_LOGS = "pref_save_logs"
         const val COMPRESSION_PRESET = "pref_compression_preset"
+        const val VIDEO_CODEC = "pref_video_codec"
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -6,11 +6,16 @@
         <item>Custom</item>
     </array>
 
-    <array name="settings_compressed_media_name_values">
+    <array name="settings_video_codec_values">
+        <item>libx265</item>
+        <item>libx264</item>
+    </array>
+
+    <string name="settings_compressed_media_name_values">
         <item>ORIGINAL</item>
         <item>UUID</item>
         <item>CUSTOM</item>
-    </array>
+    </string>
 
     <string-array name="settings_jpeg_qscale">
         <item>1</item><item>2</item><item>3</item><item>4</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -11,11 +11,11 @@
         <item>libx264</item>
     </array>
 
-    <string name="settings_compressed_media_name_values">
+    <array name="settings_compressed_media_name_values">
         <item>ORIGINAL</item>
         <item>UUID</item>
         <item>CUSTOM</item>
-    </string>
+    </array>
 
     <string-array name="settings_jpeg_qscale">
         <item>1</item><item>2</item><item>3</item><item>4</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,9 @@
     <string name="settings_video_max_file_size">Video max file size</string>
     <string name="settings_video_max_file_size_summary">Adjusts video bitrate to create an output less than the specified file size</string>
 
+    <string name="settings_video_codec">Video Codec</string>
+    <string name="settings_video_codec_summary">Video codec of output video.</string>
+
     <string name="settings_max_video_resolution" tools:ignore="MissingTranslation">Max video resolution</string>
     <string name="settings_max_video_resolution_summary" tools:ignore="MissingTranslation">Reduce the video output resolution</string>
     <string name="settings_max_image_resolution" tools:ignore="MissingTranslation">Max image resolution</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -100,6 +100,13 @@
             android:summary="@string/settings_max_image_resolution_summary"
             android:entries="@array/settings_max_resolution"
             android:entryValues="@array/settings_max_resolution_values" />
+        <ListPreference
+            android:key="pref_video_codec"
+            android:defaultValue="libx265"
+            android:title="@string/settings_video_codec"
+            android:summary="@string/settings_video_codec_summary"
+            android:entries="@array/settings_video_codec_values"
+            android:entryValues="@array/settings_video_codec_values" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
It fixes #54 and added option to change video codec between `libx264` and `libx265`

`libx265` will convert the video into `HEVC` format which uses less size with negligible change in quality.